### PR TITLE
Orphans

### DIFF
--- a/lib/OrderedTree/buildTree.test.ts
+++ b/lib/OrderedTree/buildTree.test.ts
@@ -288,21 +288,20 @@ describe("buildTree", () => {
     ).toBeCloseTo(0.1666)
   })
 
-  it("moves nodes to the root if their parent is not present", () => {
+  it.only("moves nodes to the root if their parent is not present", () => {
     const tree = buildTree({
       data: [AUNTIE, MOMMA, GRANDKID],
       ...FUNCTIONS,
       expansionOverrideMask: {},
     })
 
-    expect(tree.roots).toHaveLength(2)
-    expect(tree.roots[0].id).toBe("momma")
-    expect(tree.roots[0].children).toHaveLength(1)
-    expect(tree.roots[0].children[0].id).toBe("grandkid")
-    expect(tree.roots[1].id).toBe("auntie")
+    expect(tree.roots).toHaveLength(0)
+    expect(tree.orphanData).toHaveLength(2)
+    console.log(tree.orphanData)
+    expect(tree.orphanData[0].id).toBe("auntie")
+    expect(tree.orphanData[1].id).toBe("momma")
   })
 
-  ///
   it("filters out node trees", () => {
     const tree = buildTree({
       data: [AUNTIE, MOMMA, GRANDKID],

--- a/lib/OrderedTree/buildTree.test.ts
+++ b/lib/OrderedTree/buildTree.test.ts
@@ -288,9 +288,13 @@ describe("buildTree", () => {
     ).toBeCloseTo(0.1666)
   })
 
-  it.only("moves nodes to the root if their parent is not present", () => {
+  it("returns nodes as orphans if their parent is not present", () => {
     const tree = buildTree({
-      data: [AUNTIE, MOMMA, GRANDKID],
+      data: [
+        buildKin({ id: "auntie", parentId: "gramps" }),
+        buildKin({ id: "momma", parentId: "gramps" }),
+        buildKin({ id: "grandkid", parentId: "momma" }),
+      ],
       ...FUNCTIONS,
       expansionOverrideMask: {},
     })
@@ -304,7 +308,11 @@ describe("buildTree", () => {
 
   it("filters out node trees", () => {
     const tree = buildTree({
-      data: [AUNTIE, MOMMA, GRANDKID],
+      data: [
+        buildKin({ id: "auntie" }),
+        buildKin({ id: "momma" }),
+        buildKin({ id: "grandkid", parentId: "momma" }),
+      ],
       ...FUNCTIONS,
       isFilteredOut: (kin) => kin.id === "momma" || kin.id === "grandkid",
       expansionOverrideMask: {},
@@ -316,7 +324,11 @@ describe("buildTree", () => {
 
   it("includes children of nodes that match filters", () => {
     const tree = buildTree({
-      data: [AUNTIE, MOMMA, GRANDKID],
+      data: [
+        buildKin({ id: "auntie" }),
+        buildKin({ id: "momma" }),
+        buildKin({ id: "grandkid", parentId: "momma" }),
+      ],
       ...FUNCTIONS,
       isFilteredOut: (kin) => kin.id === "auntie",
       expansionOverrideMask: {},
@@ -348,23 +360,13 @@ describe("buildTree", () => {
 
   it("expands parents of children that match", () => {
     const tree = buildTree({
-      data: [AUNTIE, MOMMA, GRANDKID],
+      data: [
+        buildKin({ id: "auntie" }),
+        buildKin({ id: "momma", isCollapsed: true }),
+        buildKin({ id: "grandkid", parentId: "momma" }),
+      ],
       ...FUNCTIONS,
       isFilteredOut: (kin) => kin.id === "auntie",
-      expansionOverrideMask: {},
-    })
-
-    expect(tree.roots).toHaveLength(1)
-    expect(tree.roots[0].id).toBe("momma")
-    expect(tree.roots[0].children).toHaveLength(1)
-    expect(tree.roots[0].children[0].id).toBe("grandkid")
-  })
-
-  it("includes collapsed nodes that match filters", () => {
-    const tree = buildTree({
-      data: [AUNTIE, { ...MOMMA, isCollapsed: true }, GRANDKID],
-      ...FUNCTIONS,
-      isFilteredOut: (kin) => kin.id !== "grandkid",
       expansionOverrideMask: {},
     })
 

--- a/lib/OrderedTree/useOrderedTree.tsx
+++ b/lib/OrderedTree/useOrderedTree.tsx
@@ -69,6 +69,7 @@ type GetNodeProps = () => {
 
 type UseOrderedTreeReturnType<Datum> = {
   roots: Datum[]
+  orphans: Datum[]
   getTreeProps: GetTreeProps
   TreeProvider(this: void, props: { children: React.ReactNode }): JSX.Element
   getKey(this: void, datum: Datum): string
@@ -313,6 +314,7 @@ export function useOrderedTree<Datum>({
     isDropping,
     isCollapsed: (datum) => model.getExpansion(datum) === "collapsed",
     setCollapsed,
+    orphans: tree.orphanData,
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-headless-accessible-hooks",
-  "version": "0.13.0-beta.0",
+  "version": "0.13.0-beta.1",
   "license": "MIT",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-headless-accessible-hooks",
-  "version": "0.12.0",
+  "version": "0.13.0-beta.0",
   "license": "MIT",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.es.js",


### PR DESCRIPTION
Instead of reparenting them, returns an `orphans` array from `useOrderedTree`.