### PR TITLE
Better handle non-moves

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2023 Erik Pukinskis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/OrderedTree/useOrderedTree.tsx
+++ b/lib/OrderedTree/useOrderedTree.tsx
@@ -349,16 +349,10 @@ export function useOrderedTreeNode<Datum>(
   // corresponding node. So this node is the node for the original datum, and
   // node.data will be a different object than the placeholder datum:
   const node = model.getNode(datum)
-  const isBeingDragged = model.isBeingDragged(datum)
   const isPlaceholder = model.isPlaceholder(datum)
-  const childIsBeingDragged = model.childIsBeingDragged(node.id)
 
-  const { children, expansion } = useParent(
-    node.children,
-    datum,
-    model,
-    isPlaceholder
-  )
+  const { children, expansion, isBeingDragged, childIsBeingDragged } =
+    useParent(node.children, datum, model, isPlaceholder)
 
   const getNodeProps = useCallback<GetNodeProps>(() => {
     return {
@@ -397,12 +391,16 @@ export function useOrderedTreeNode<Datum>(
 type UseParentReturnType<Datum> = {
   children: Datum[]
   expansion: "expanded" | "collapsed" | "no children"
+  isBeingDragged: boolean
+  childIsBeingDragged: boolean
 }
 
 type ParentState = {
   placeholderOrder: number | null
   expansion: "expanded" | "collapsed" | "no children"
   isDropping: boolean
+  isBeingDragged: boolean
+  childIsBeingDragged: boolean
 }
 
 /**
@@ -440,6 +438,8 @@ function useParent<Datum>(
       placeholderOrder: null,
       expansion,
       isDropping: false,
+      isBeingDragged: false,
+      childIsBeingDragged: false,
     }
   })
 
@@ -459,6 +459,7 @@ function useParent<Datum>(
 
     const handleNodeChange: NodeListener = (change) => {
       setState((oldState) => {
+        console.log(parentId, change, { oldState })
         return { ...oldState, ...change }
       })
     }
@@ -541,6 +542,8 @@ function useParent<Datum>(
   return {
     children,
     expansion: state.expansion,
+    isBeingDragged: state.isBeingDragged,
+    childIsBeingDragged: state.childIsBeingDragged,
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -67,5 +67,6 @@
     "test": "vitest run --config vite.test.config.js --reporter verbose",
     "watch:problems": "tsc --watch --noEmit -p tsconfig.json",
     "watch:test": "vitest watch --config vite.test.config.js"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
There were a couple issues here this PR fixes:

1) When just dragging a pixel or two, we would fail to fire a click event, which made `onClick` feel janky.
2) If we dragged a node slightly, but not enough to change the order, it would still fire an `onNodeMove` event, even though no node moved. This was causing apps to get stuck in the loading state sometimes.

In order to fix this, I made more of the business of completing the drag happen in the `finishDrop` method, and I call that more liberally. Before I think we were relying on `setTree` coming through to complete drags. I also needed to push more information to the node parents (`isBeingDragged`, `childIsBeingDragged`, etc) because that state needs to be reset in these cases where `onNodeMove` never fires.