### PR TITLE
Add `onBlur` to `useSelect` and disable aria-active-descendant

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Necessary for an V1 release:
 - [ ] Accessibility announce & roles
 - [ ] Don't pause dragging while waiting for a fresh tree
 - [ ] Figure out aria-activedescendant focus issue
+- [ ] Allow `null` or `undefined` to be assed to `useOrderedTree` `data`
 
 Maybes:
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Necessary for an V1 release:
 - [ ] Keyboard control
 - [ ] Accessibility announce & roles
 - [ ] Don't pause dragging while waiting for a fresh tree
+- [ ] Figure out aria-activedescendant focus issue
 
 Maybes:
 

--- a/lib/Select/useSelect.ts
+++ b/lib/Select/useSelect.ts
@@ -8,6 +8,7 @@ type SelectOptions<Datum> = {
   onSelect?: (
     item: Datum
   ) => boolean | void | undefined | Promise<boolean | void | undefined>
+  onBlur?(): void
   minQueryLength?: number
 }
 
@@ -16,6 +17,7 @@ export const useSelect = <Datum>({
   label,
   getOptionValue,
   onSelect,
+  onBlur,
 }: SelectOptions<Datum>) => {
   const [isHidden, setHidden] = useState(true)
   const [highlightedIndex, setHighlightedIndex] = useState<number>(-1)
@@ -39,8 +41,9 @@ export const useSelect = <Datum>({
       if (focusedElementCountRef.current) return
       if (didMouseDownOnOptionRef.current) return
       setHidden(true)
+      onBlur?.()
     })
-  }, [focusedElementCount])
+  }, [focusedElementCount, onBlur])
 
   const valuesHash = useMemo(() => {
     return data?.map(getOptionValue).join("-----")
@@ -71,6 +74,7 @@ export const useSelect = <Datum>({
   const handleKeys = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Escape") {
       setHidden(true)
+      onBlur?.()
       return
     }
 

--- a/lib/Select/useSelect.ts
+++ b/lib/Select/useSelect.ts
@@ -50,17 +50,17 @@ export const useSelect = <Datum>({
     setHighlightedIndex(0)
   }, [valuesHash])
 
-  const activeDescendantId = useMemo(
-    function updateActiveDescendant() {
-      if (highlightedIndex === -1) return undefined
-      if (!data) return undefined
-      if (data.length < 1) return undefined
-      const item = data[highlightedIndex]
-      if (!item) return undefined
-      return getOptionValue(item)
-    },
-    [highlightedIndex, data, getOptionValue]
-  )
+  // const activeDescendantId = useMemo(
+  //   function updateActiveDescendant() {
+  //     if (highlightedIndex === -1) return undefined
+  //     if (!data) return undefined
+  //     if (data.length < 1) return undefined
+  //     const item = data[highlightedIndex]
+  //     if (!item) return undefined
+  //     return getOptionValue(item)
+  //   },
+  //   [highlightedIndex, data, getOptionValue]
+  // )
 
   const selectItem = async (item: Datum) => {
     const hide = await onSelect?.(item)
@@ -132,7 +132,8 @@ export const useSelect = <Datum>({
       "onBlur": () => {
         focus(false)
       },
-      "aria-activedescendant": activeDescendantId,
+      // This is making focus get stuck on the input on load sometimes (with an Evergreen TagInput anyway)
+      // "aria-activedescendant": activeDescendantId,
       "onKeyDownCapture": handleKeys,
     }),
     getListboxProps: () => ({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-headless-accessible-hooks",
-  "version": "0.21.0-beta.0",
+  "version": "0.21.0-beta.1",
   "license": "MIT",
   "repository": {
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-headless-accessible-hooks",
-  "version": "0.20.0",
+  "version": "0.21.0-beta.0",
   "license": "MIT",
   "repository": {
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-headless-accessible-hooks",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "MIT",
   "repository": {
     "repository": {


### PR DESCRIPTION
The `onBlur` is useful for clearing the query, and `aria-active-descendant` wasn't working right, causing focus issues. Need to revisit.